### PR TITLE
feat: use panel dir in working directory, if found

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -21,8 +21,8 @@ samples = pd.read_csv(config["samples"], sep="\t", comment="#")
 validate(samples, "../schema/samples.schema.yaml")
 
 panel_path = Path(config["panel_filtering"]["panel_directory"])
-if not panel_path.is_absolute():
-    panel_path = Path(snakemake.workflow.srcdir("../.."), panel_path)
+if not panel_path.exists() and not panel_path.is_absolute():
+    panel_path = Path(snakemake.workflow.srcdir("../.."), panel_path).resolve()
 
 wildcard_constraints:
     ext=r"vcf(\.gz)?$",
@@ -33,6 +33,8 @@ def _get_sample_row(wildcards):
 
 def get_panel_dict():
     panels = {}
+    if not panel_path.exists():
+        raise FileNotFoundError(f"directory not found: {panel_path}")
     for p in panel_path.glob("*.tsv"):
         panels[p.stem] = p
     return panels

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -48,7 +48,11 @@ def get_sample_panels(wildcards):
 
 def get_panel_files(wildcards):
     panel_dict = get_panel_dict()
-    return [panel_dict[p] for p in get_sample_panels(wildcards)]
+    try:
+        panel_files = [panel_dict[p] for p in get_sample_panels(wildcards)]
+    except KeyError as ie:
+        raise KeyError(f"panel not found: {ie}")
+    return panel_files
 
 def get_vcf_file(wildcards):
     vcf_filename = _get_sample_row(wildcards)["vcf"].values

--- a/workflow/schema/config.schema.yaml
+++ b/workflow/schema/config.schema.yaml
@@ -35,8 +35,9 @@ properties:
         description: >
           Directory where Scout panel files are kept, see
           https://clinical-genomics.github.io/scout/user-guide/panels/.
-          If this is a relative path, it is assumed that it is relative to
-          the root of the scout-annotation workflow repository.
+          If this is a relative path which is not found in the current working
+          directory, the workflow will try to locate it in the root of the
+          scout-annotation workflow repository.
         format: uri-reference
         default: panels
     required:


### PR DESCRIPTION
The previous behaviour always tried to look in the repo root for a relative path, which would be confusing if you were intending to point to an existing panel dir in the working directory. This PR makes it so that if the directory is not found in the working directory, it looks in the repo root.