### PR TITLE
fix: issue with bam path in load config

### DIFF
--- a/scout_annotation/workflow/rules/scout_load_config.smk
+++ b/scout_annotation/workflow/rules/scout_load_config.smk
@@ -35,7 +35,7 @@ rule scout_load_config_sample:
         yaml=temp("load_config/{family}_{sample}.load_config.yaml"),
     params:
         type="sample",
-        bam=get_bam_file,
+        include_bam=lambda wc: isinstance(get_bam_file(wc), Path),
         sex=get_sample_sex,
         analysis_type=get_analysis_type,
     container:

--- a/scout_annotation/workflow/scripts/scout_load_config.py
+++ b/scout_annotation/workflow/scripts/scout_load_config.py
@@ -34,7 +34,7 @@ def phenotype(ped_path, sample):
 
 def generate_sample_config(sample):
     ped_file = snakemake.input.ped
-    bam = snakemake.params.bam
+    include_bam = snakemake.params.include_bam
     sex = snakemake.params.sex
     analysis_type = snakemake.params.analysis_type
 
@@ -45,7 +45,7 @@ def generate_sample_config(sample):
         "analysis_type": analysis_type,
     }
 
-    if isinstance(bam, Path):
+    if include_bam:
         sample_config["alignment_path"] = "{}.bam".format(snakemake.wildcards.sample)
 
     return sample_config

--- a/scout_annotation/workflow/scripts/scout_load_config.py
+++ b/scout_annotation/workflow/scripts/scout_load_config.py
@@ -45,8 +45,8 @@ def generate_sample_config(sample):
         "analysis_type": analysis_type,
     }
 
-    if len(bam) > 0:
-        sample_config["alignment_path"] = bam
+    if isinstance(bam, Path):
+        sample_config["alignment_path"] = "{}.bam".format(snakemake.wildcards.sample)
 
     return sample_config
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -224,10 +224,12 @@ def test_cli_batch(cli_batch):
 
 def test_cli_batch_load_config(cli_batch):
     config_path = Path(cli_batch[1], "cli_batch_results/HD832/HD832.load_config.yaml")
+    bam_path = Path(cli_batch[1], "cli_batch_results/HD832/HD832.bam")
     with open(config_path) as f:
         load_config = yaml.safe_load(f)
 
     assert load_config["samples"][0]["alignment_path"] == "HD832.bam"
+    assert bam_path.exists()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -202,6 +202,8 @@ def cli_batch():
         "--cores",
         "1",
         "batch",
+        "--bam-dir",
+        "../batch_data/bam",
         "--notemp",
         "-o",
         "cli_batch_results",
@@ -218,6 +220,14 @@ def test_cli_batch(cli_batch):
     results_dir = cli_batch[1]
     assert results_dir.exists()
     assert results_dir.is_dir()
+
+
+def test_cli_batch_load_config(cli_batch):
+    config_path = Path(cli_batch[1], "cli_batch_results/HD832/HD832.load_config.yaml")
+    with open(config_path) as f:
+        load_config = yaml.safe_load(f)
+
+    assert load_config["samples"][0]["alignment_path"] == "HD832.bam"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
When supplying a bam file for the sample load config it would crash since a pathlib PosixPath does not have a length. In addition, the filename given to the load config was an absolute path to the original bam file, which most likely would be incorrect in the end. As a solution to this I now pass a boolean value which is true if the results from `get_bam_file` is a path, and false otherwise. Then the path to the final bam file is constructed in `scout_load_config.py`.