### PR TITLE
fix: allow for numbers at the beginning of a sample name

### DIFF
--- a/scout_annotation/workflow/rules/common.smk
+++ b/scout_annotation/workflow/rules/common.smk
@@ -69,8 +69,8 @@ samples["family"] = np.where(
 
 wildcard_constraints:
     ext=r"vcf(\.gz)?$",
-    family=r"[a-zA-Z][-a-zA-Z0-9]+",
-    sample=r"[a-zA-Z][-a-zA-Z0-9]+",
+    family=r"[a-zA-Z0-9][-a-zA-Z0-9]+[^-]",
+    sample=r"[a-zA-Z0-9][-a-zA-Z0-9]+[^-]",
     track=r"(rare_disease|cancer)",
 
 

--- a/scout_annotation/workflow/schema/samples.schema.yaml
+++ b/scout_annotation/workflow/schema/samples.schema.yaml
@@ -3,11 +3,11 @@ description: a row in the sample table
 properties:
   sample:
     type: string
-    pattern: "^[a-zA-Z][-a-zA-Z0-9]+[^-]$"
+    pattern: "^[a-zA-Z0-9][-a-zA-Z0-9]+[^-]$"
     description: Sample ID
   family:
     type: string
-    pattern: "^[a-zA-Z][-a-zA-Z0-9]+[^-]$"
+    pattern: "^[a-zA-Z0-9][-a-zA-Z0-9]+[^-]$"
     description: >
       ID of the family that the sample belongs to. If a PED file
       is given, the family ID in the PED filem must match this value

--- a/tests/integration/data/samples.tsv
+++ b/tests/integration/data/samples.tsv
@@ -6,3 +6,4 @@ sample4	clingen	unknown	panel	rare_disease	rare_disease	data/HD832_chr7_twist-so
 sample5	clingen-somatic	unknown	panel	somatic	cancer	data/HD832_chr7_twist-solid-0.1.5-alpha.vcf		test_panel1,test_panel2
 sample6	clingen	unknown	panel	rare_disease	rare_disease	data/HD832_chr7_twist-solid-0.1.5-alpha.vcf		test_panel3
 sample7	clingen	unknown	panel	strict	rare_disease	data/HD832_chr7_twist-solid-0.1.5-alpha.vcf		test_panel2
+8-sample	clingen	unknown	panel	strict	rare_disease	data/HD832_chr7_twist-solid-0.1.5-alpha.vcf		test_panel2


### PR DESCRIPTION
I don't remember the rationale for not allowing numbers at the beginning of a sample name, but I think that is overly restrictive, especially considering that some of our old IDs do start with numbers. This allows us to use those IDs all the way through, and that should minimise any confusion.