### PR TITLE
fix: Do not convert msi, hrd and tmb values as integers

### DIFF
--- a/scout_annotation/workflow/rules/common.smk
+++ b/scout_annotation/workflow/rules/common.smk
@@ -322,19 +322,19 @@ def get_msi(wildcards):
     msi_score = samples[samples["sample"] == wildcards.sample]["msi_score"][0]
     if pd.isnull(msi_score):
         return None
-    return int(msi_score)
+    return msi_score
 
 def get_hrd(wildcards):
     hrd_score = samples[samples["sample"] == wildcards.sample]["hrd_score"][0]
     if pd.isnull(hrd_score):
         return None
-    return int(hrd_score)
+    return hrd_score
 
 def get_tmb(wildcards):
     tmb_score = samples[samples["sample"] == wildcards.sample]["tmb_score"][0]
     if pd.isnull(tmb_score):
         return None
-    return int(tmb_score)
+    return tmb_score
 
 def get_vcf_samples(vcf_filename):
     vcf = cyvcf2.VCF(vcf_filename)

--- a/scout_annotation/workflow/scripts/scout_load_config.py
+++ b/scout_annotation/workflow/scripts/scout_load_config.py
@@ -51,11 +51,11 @@ def generate_sample_config(sample):
     }
 
     if msi_score is not None:
-        sample_config["msi"] = int(msi_score)
+        sample_config["msi"] = str(msi_score)
     if hrd_score is not None:
-        sample_config["hrd"] = int(hrd_score)
+        sample_config["hrd"] = str(hrd_score)
     if tmb_score is not None:
-        sample_config["tmb"] = int(tmb_score)
+        sample_config["tmb"] = str(tmb_score)
 
     if include_bam:
         sample_config["alignment_path"] = "{}/{}.bam".format(out_dir,snakemake.wildcards.sample)


### PR DESCRIPTION
TMB, HRD, and MSI were parsed as integers, based on the documentation on scout. The values are now printed as strings in the load_config