### PR TITLE
fix: address issue with empty string gene panels

### DIFF
--- a/scout_annotation/workflow/rules/common.smk
+++ b/scout_annotation/workflow/rules/common.smk
@@ -232,7 +232,7 @@ def get_preprocessed_vcf_index(wildcards):
 def get_family_panels(wildcards):
     panels = samples[samples["family"] == wildcards["family"]]["panels"].unique()
     assert len(panels) == 1, "all samples in a family need to have the same panels"
-    if pd.isnull(panels[0]):
+    if pd.isnull(panels[0]) or not panels[0]:
         return []
     return panels[0].split(",")
 
@@ -240,7 +240,7 @@ def get_family_panels(wildcards):
 def get_family_snv_filter_tag(wildcards):
     filtering = samples[samples["family"] == wildcards.family]["filtering"].unique()
     assert len(filtering) == 1, "all samples in a family must use the same filters"
-    if pd.isnull(filtering[0]) or filtering[0] == "":
+    if pd.isnull(filtering[0]) or not filtering[0]:
         return None
     return filtering[0]
 

--- a/scout_annotation/workflow/schema/samples.schema.yaml
+++ b/scout_annotation/workflow/schema/samples.schema.yaml
@@ -49,9 +49,11 @@ properties:
     description: path to PED file for the sample
     format: uri-reference
   panels:
-    type: string
+    type:
+      - string
+      - "null"
     description: comma separated list of panels to apply to sample
-    default: ""
+    default: null
   bam:
     type: string
     description: path to BAM file for the sample

--- a/tests/cli_integration_test.py
+++ b/tests/cli_integration_test.py
@@ -130,8 +130,17 @@ def test_cli_batch_load_config(cli_batch):
     with open(config_path) as f:
         load_config = yaml.safe_load(f)
 
+    assert not load_config.get("gene_panels", [])
     assert load_config["samples"][0]["alignment_path"] == str(bam_path)
     assert bam_path.exists()
+
+
+def test_cli_single_load_config(cli_single):
+    config_path = Path(cli_single, "results/HD832/HD832.load_config.yaml")
+    with open(config_path) as f:
+        load_config = yaml.safe_load(f)
+
+    assert not load_config.get("gene_panels", [])
 
 
 def test_trio_vcf_samples(cli_trio):


### PR DESCRIPTION
When running the pipeline with no gene panel set, the schema validation converted this to an empty string. This in turn triggered a lot of extra rules for no reason when the panel filtering wasn't required. For some reason this didn't crash downstream.

This commit addresses this by setting the default to `null` in the JSON schema. Test cases were added to the integration tests that will catch this issue. It would have been nicer to have this as a unit test, but this requires a refactor of the sample handling, and this is something I will get to at a later time.