### PR TITLE
fix: keep the undecomposed SNVs from clumped variants

### DIFF
--- a/tests/snakemake_integration_test.py
+++ b/tests/snakemake_integration_test.py
@@ -54,7 +54,7 @@ def test_integration_fixture_runs(integration):
 
 
 @pytest.fixture(
-    params=[("family1", "sample1", 158), ("family2", "sample2", 158)],
+    params=[("family1", "sample1", 162), ("family2", "sample2", 162)],
     scope="session",
     ids=lambda x: x[0],
 )

--- a/tests/test_undecompose.py
+++ b/tests/test_undecompose.py
@@ -84,9 +84,7 @@ def test_parse_old_clumped_valid_and_invalid_values():
     assert parse_old_clumped("chr1:100:A>C") is None
 
 
-def test_undecompose_merges_same_old_clumped_and_preserves_first_record_fields(
-    tmp_path, vcf_header, make_record
-):
+def test_undecompose_merges_same_old_clumped(tmp_path, vcf_header, make_record):
     input_vcf = tmp_path / "input.vcf"
     output_vcf = tmp_path / "output.vcf"
 
@@ -207,11 +205,11 @@ def test_undecompose_merges_same_old_clumped_and_preserves_first_record_fields(
     with pysam.VariantFile(output_vcf) as vcf:
         out = list(vcf)
 
-    assert len(out) == 6
+    assert len(out) == 13
 
-    merged1 = out[0]
-    merged2 = out[1]
-    merged3 = out[3]
+    merged1 = out[1]
+    merged2 = out[4]
+    merged3 = out[8]
     unmerged1 = out[4]
     unmerged2 = out[5]
     assert merged1.contig == "chr1"
@@ -236,19 +234,9 @@ def test_undecompose_merges_same_old_clumped_and_preserves_first_record_fields(
     assert merged3.pos == 200
     assert tuple(merged3.alleles) == ("TATT", "GTTC")
 
-    unchanged = out[2]
-    assert unchanged.pos == 105
-    assert tuple(unchanged.alleles) == ("G", "T")
-    assert unchanged.info["DP"] == 25
-    assert unchanged.samples["S1"]["GT"] == (1, 1)
-
-    assert unmerged1.pos == 300
-    assert tuple(unmerged1.alleles) == ("A", "G")
-    assert unmerged1.info["OLD_CLUMPED"] == "chr3:300:ACGT/GGGC"
-
-    assert unmerged2.pos == 303
-    assert tuple(unmerged2.alleles) == ("T", "C")
-    assert unmerged2.info["OLD_CLUMPED"] == "chr3:300:ACGT/GGGC"
+    # Assert incomplete MNV is not present "chr3:300:ACGT/GGGC"
+    for rec in out:
+        assert tuple(rec.alleles) != ("ACGT", "GGGC")
 
 
 def test_undecompose_flushes_when_old_clumped_group_changes(
@@ -273,11 +261,11 @@ def test_undecompose_flushes_when_old_clumped_group_changes(
     with pysam.VariantFile(output_vcf) as vcf:
         out = list(vcf)
 
-    assert len(out) == 2
-    assert out[0].pos == 100
-    assert tuple(out[0].alleles) == ("AA", "CC")
-    assert out[1].pos == 200
-    assert tuple(out[1].alleles) == ("GG", "TT")
+    assert len(out) == 6
+    assert out[1].pos == 100
+    assert tuple(out[1].alleles) == ("AA", "CC")
+    assert out[4].pos == 200
+    assert tuple(out[4].alleles) == ("GG", "TT")
 
 
 def test_expected_decomposed_snvs_returns_only_changed_positions():

--- a/workflow/scripts/undecompose_vcf.py
+++ b/workflow/scripts/undecompose_vcf.py
@@ -246,14 +246,12 @@ def undecompose(vcf_in: str, vcf_out: str) -> None:
                 old_txt = record.info.get("OLD_CLUMPED")
                 old = parse_old_clumped(old_txt)
 
-                # no OLD_CLUMPED -> always keep as-is
+                out_vcf.write(record)
+
                 if old is None:
-                    out_vcf.write(record)
                     continue
 
-                # incomplete/invalid group -> keep decomposed record as-is
                 if old not in complete_groups:
-                    out_vcf.write(record)
                     continue
 
                 # complete group: write merged once, skip the rest

--- a/workflow/scripts/undecompose_vcf.py
+++ b/workflow/scripts/undecompose_vcf.py
@@ -272,8 +272,8 @@ def undecompose(vcf_in: str, vcf_out: str) -> None:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
     try:
+        logging.basicConfig(level=logging.INFO, filename=snakemake.log[0])
         log = snakemake.log_fmt_shell(stdout=False, stderr=True)
         undecompose(
             snakemake.input.vcf,
@@ -282,6 +282,7 @@ if __name__ == "__main__":
     except NameError:
         import argparse
 
+        logging.basicConfig(level=logging.INFO)
         p = argparse.ArgumentParser()
         p.add_argument("-i", "--input-vcf", required=True)
         p.add_argument("-o", "--output-vcf", required=True)


### PR DESCRIPTION
Now SNV records obtained from ```vt blocksub ... ``` are kept, alongside with the recreated MNV. 