### PR TITLE
fix: snakemake version mismatch

### DIFF
--- a/default_config/config.yaml
+++ b/default_config/config.yaml
@@ -2,7 +2,7 @@ samples: "samples.tsv"
 
 output_directory: results
 
-default_container: docker://snakemake/snakemake:v9.18.2
+default_container: docker://python:3.12-alpine
 
 reference:
   fasta: /storage/userdata/references/homo_sapiens/hg19/fasta/hg19.fa.gz

--- a/default_config/config.yaml
+++ b/default_config/config.yaml
@@ -2,7 +2,7 @@ samples: "samples.tsv"
 
 output_directory: results
 
-default_container: docker://snakemake/snakemake:v9.14.0
+default_container: docker://snakemake/snakemake:v9.18.2
 
 reference:
   fasta: /storage/userdata/references/homo_sapiens/hg19/fasta/hg19.fa.gz

--- a/default_config/config.yaml
+++ b/default_config/config.yaml
@@ -2,7 +2,7 @@ samples: "samples.tsv"
 
 output_directory: results
 
-default_container: docker://python:3.12-alpine
+default_container: docker://python:3.12
 
 reference:
   fasta: /storage/userdata/references/homo_sapiens/hg19/fasta/hg19.fa.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 license = "GPL-3.0-or-later"
 readme = "README.md"
 dependencies = [
-    "snakemake==9.18.2",
+    "snakemake~=9.14",
     "snakemake-executor-plugin-slurm~=2.1",
 ]
 requires-python = "~=3.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 license = "GPL-3.0-or-later"
 readme = "README.md"
 dependencies = [
-    "snakemake>=9.14.5",
+    "snakemake==9.18.2",
     "snakemake-executor-plugin-slurm~=2.1",
 ]
 requires-python = "~=3.12.0"

--- a/workflow/rules/normalise.smk
+++ b/workflow/rules/normalise.smk
@@ -28,7 +28,7 @@ rule undecompose:
     log:
         decompose_dir + "/{family}/{family}.undecomposed.log",
     container:
-        "docker://quay.io/biocontainers/pysam:0.15.2--py38h7be0bb8_11"
+        "docker://quay.io/biocontainers/pysam:0.23.3--py312h8f9e533_2"
     script:
         "../scripts/undecompose_vcf.py"
 
@@ -85,7 +85,7 @@ rule rename_callers:
         callers_map={"gatk_mutect2": "gatk", "mutect2": "gatk"},
         callers_field="FOUND_IN",
     container:
-        "docker://quay.io/biocontainers/pysam:0.15.2--py38h7be0bb8_11"
+        "docker://quay.io/biocontainers/pysam:0.23.3--py312h8f9e533_2"
     script:
         "../scripts/rename_callers.py"
 
@@ -102,7 +102,7 @@ rule fix_vcf_af:
     log:
         decompose_dir + "/{family}/{family}.fix-af.log",
     container:
-        "docker://quay.io/biocontainers/pysam:0.15.2--py38h7be0bb8_11"
+        "docker://quay.io/biocontainers/pysam:0.23.3--py312h8f9e533_2"
     script:
         "../scripts/fix_vcf_af.py"
 


### PR DESCRIPTION
There were issues with the Snakemake version in `pyproject.toml` not matching with the version in the default container. This has now been addressed by setting the version to `~=9.14` in `pyproject.toml` instead of `>=9.14.5` to avoid that we accidentally go to the next major version, and just using a plain Python container as the default container.

In doing this I also saw some issues with older Python versions in the pysam containers. This was fixed by simply updating the container to a newer version of pysam with Python 3.12.