### PR TITLE
fix: remove default resources from default profile

### DIFF
--- a/workflow/profiles/default/config.v9+.yaml
+++ b/workflow/profiles/default/config.v9+.yaml
@@ -1,11 +1,5 @@
 software-deployment-method: apptainer
 
-default-resources:
-  runtime: 1h
-  cpus_per_task: 1
-  mem_mb: 4000
-  mem_mb_per_cpu: 4000
-
 set-threads:
   vep: 4
   vcfanno: 4


### PR DESCRIPTION
This issue was very annoying. I was trying to set the slurm partition in a separate profile when implementing the plumber support, but I could never get it to be applied when doing it this way. Setting it on the command line worked, but no resources would be applied when using a profile.

It turns out that having default resources set in the default profile of the pipeline prevents them from being overridden in other profiles. This feels very much like a Snakemake bug. I've seen related issues on their issue tracker, but not this one specifically. They might be related though.

Removing the default resources from the default profile seems to fix the issue, and I can now set the resources with a separate profile.