### PR TITLE
feat: annotated vcf files are always indexed with tabix

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -4,7 +4,7 @@ include: "rules/annotate.smk"
 include: "rules/coverage.smk"
 
 
-outputs_files = output_vcfs + output_d4s
+outputs_files = output_vcfs + output_tbis + output_d4s
 
 
 rule all:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -36,6 +36,12 @@ output_vcfs = [
     f"{annotation_dir}/{family}/{family}.annotated.genmod.vcf.gz"
     for family in family_dict.keys()
 ]
+
+output_tbis = [
+    f"{annotation_dir}/{family}/{family}.annotated.genmod.vcf.gz.tbi"
+    for family in family_dict.keys()
+]
+
 output_d4s = []
 for sample, sample_data in sample_dict.items():
     if sample_data.get("bam") is not None:


### PR DESCRIPTION
This should create tbi-files for the annotated vcf-files